### PR TITLE
Return the payment after executing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ class PaymentController extends Controller
      */
     public function execute(Request $request)
     {
-        return ['result' => Payment::execute($request->payment_id, $request->payer_id)->getState() !== 'failed'];
+        return ['result' => Payment::execute($request->payment_id, $request->payer_id) !== false];
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ class PaymentController extends Controller
      */
     public function execute(Request $request)
     {
-        return ['result' => Payment::execute($request->payment_id, $request->payer_id)];
+        return ['result' => Payment::execute($request->payment_id, $request->payer_id) !== 'failed'];
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ class PaymentController extends Controller
      */
     public function execute(Request $request)
     {
-        return ['result' => Payment::execute($request->payment_id, $request->payer_id) !== 'failed'];
+        return ['result' => Payment::execute($request->payment_id, $request->payer_id)->getState() !== 'failed'];
     }
 }
 ```

--- a/src/Classes/Payment.php
+++ b/src/Classes/Payment.php
@@ -177,7 +177,7 @@ class Payment
      * @param  int $payer_id
      * @param  string $client_id
      * @param  string $client_secret
-     * @return bool
+     * @return \PayPal\Api\Payment
      */
     public static function execute($payment_id, $payer_id, $client_id = null, $client_secret = null)
     {
@@ -207,7 +207,7 @@ class Payment
             return false;
         }
 
-        return true;
+        return $payment;
     }
 
     /**


### PR DESCRIPTION
Returning the actual paypal payment object if a payment is successful allows you to work with the payment after it has been executed, e.g. you might want to increase a user's account balance based on the payment amount.